### PR TITLE
기능: UFO-별똥별 충돌 시 게임 오버 처리

### DIFF
--- a/index.html
+++ b/index.html
@@ -475,6 +475,35 @@
             return false;
         }
 
+        // UFO와 별똥별 충돌 검사
+        function checkUFOShootingStarCollisions() {
+            const ufoCollisionBox = {
+                x: ufo.x,
+                y: ufo.y,
+                width: ufo.width,
+                height: ufo.height
+            };
+
+            for (let star of shootingStars) {
+                // 별똥별의 머리 부분을 중심으로 10x10 픽셀의 충돌 영역 설정
+                const starCollisionBox = {
+                    x: star.x - 5, // 중심점을 기준으로 x 위치 조정
+                    y: star.y - 5, // 중심점을 기준으로 y 위치 조정
+                    width: 10,
+                    height: 10
+                };
+
+                // 충돌 검사
+                if (ufoCollisionBox.x < starCollisionBox.x + starCollisionBox.width &&
+                    ufoCollisionBox.x + ufoCollisionBox.width > starCollisionBox.x &&
+                    ufoCollisionBox.y < starCollisionBox.y + starCollisionBox.height &&
+                    ufoCollisionBox.y + ufoCollisionBox.height > starCollisionBox.y) {
+                    return true; // 충돌 발생
+                }
+            }
+            return false; // 충돌 없음
+        }
+
         // 게임 루프
         function gameLoop(currentTime) {
             const deltaTime = currentTime - lastTime;
@@ -532,6 +561,15 @@
                 checkMissileCollisions();
                 
                 if (checkUFOCollisions()) {
+                    gameState = 'gameOver';
+                    finalTimeSpan.textContent = survivalTime;
+                    finalScoreSpan.textContent = score;
+                    gameOverDiv.classList.remove('hidden');
+                    gameInfo.classList.add('hidden');
+                }
+
+                // UFO와 별똥별 충돌 검사
+                if (checkUFOShootingStarCollisions()) {
                     gameState = 'gameOver';
                     finalTimeSpan.textContent = survivalTime;
                     finalScoreSpan.textContent = score;


### PR DESCRIPTION
UFO가 별똥별에 맞으면 게임이 종료되도록 수정했습니다.

주요 변경 사항:
- `checkUFOShootingStarCollisions()` 함수 추가: UFO와 별똥별 간의 충돌을 감지합니다. 별똥별의 머리 부분을 기준으로 충돌 영역을 설정했습니다.
- `gameLoop()` 함수 수정: `checkUFOShootingStarCollisions()`를 호출하여 충돌 발생 시 게임 상태를 'gameOver'로 변경하고, 최종 시간 및 점수를 표시합니다.

다음 사항을 확인했습니다:
- UFO가 별똥별과 충돌하면 게임이 올바르게 종료됩니다.
- 기존의 운석 충돌 기능은 정상적으로 작동합니다.
- 별똥별은 난이도 5부터 정상적으로 등장합니다.